### PR TITLE
Add missing import

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -1,4 +1,5 @@
 import kotoAssert from './assert.js';
+import d3 from 'd3';
 
 /**
  * Create a layer using the provided `base`. The layer instance is *not*


### PR DESCRIPTION
Minor omission but ended up being pretty hard to track down. For reference, the way this manifested in my project was as an undefined reference to `d3` when asserting `instanceof d3.selection`.